### PR TITLE
fix "Type name X redefined from module X"

### DIFF
--- a/src/echoes/macro/ComponentStorageBuilder.hx
+++ b/src/echoes/macro/ComponentStorageBuilder.hx
@@ -41,7 +41,7 @@ class ComponentStorageBuilder {
 			}
 		}
 		
-		Context.defineType(def);
+		try Context.getType(storageTypeName) catch (e:Dynamic) Context.defineType(def);
 		
 		storageCache.set(storageTypeName, storageType);
 		


### PR DESCRIPTION
When using the haxe compilation server I get the following error after the initial build:

```
/home/carl/haxelib/echoes/git/src/echoes/macro/ComponentStorageBuilder.hx:36: lines 36-42 : Type name ComponentStorage_h3dsceneObject is redefined from module ComponentStorage_h3dsceneObject
```

The fix was adapted from this comment: https://github.com/HaxeFoundation/haxe/issues/8368#issuecomment-829073562