### PR TITLE
Fix: Serialize idPool.

### DIFF
--- a/src/echoes/Echoes.hx
+++ b/src/echoes/Echoes.hx
@@ -227,7 +227,7 @@ class Echoes {
 	public static function serialize():String {
 		final data:Dynamic = {
 			"echoes.Echoes.activeEntities": activeEntities,
-			"echoes.Entity.idPool": Entity.idPool.copy()
+			"echoes.Entity.idPool": Entity.idPool
 		};
 		
 		for(storage in componentStorage) {

--- a/src/echoes/Echoes.hx
+++ b/src/echoes/Echoes.hx
@@ -226,7 +226,8 @@ class Echoes {
 	
 	public static function serialize():String {
 		final data:Dynamic = {
-			"echoes.Echoes.activeEntities": activeEntities
+			"echoes.Echoes.activeEntities": activeEntities,
+			"echoes.Entity.idPool": Entity.idPool.copy()
 		};
 		
 		for(storage in componentStorage) {
@@ -263,6 +264,11 @@ class Echoes {
 		for(entity in (Reflect.field(data, "echoes.Echoes.activeEntities"):Array<Entity>)) {
 			activeEntityIndices[entity.id] = _activeEntities.length;
 			_activeEntities.push(entity);
+		}
+		
+		Entity.idPool.resize(0);
+		for(id in (Reflect.field(data, "echoes.Entity.idPool"):Array<Int>)) {
+			Entity.idPool.push(id);
 		}
 		
 		for(storage in componentStorage) {

--- a/src/echoes/Echoes.hx
+++ b/src/echoes/Echoes.hx
@@ -227,7 +227,8 @@ class Echoes {
 	public static function serialize():String {
 		final data:Dynamic = {
 			"echoes.Echoes.activeEntities": activeEntities,
-			"echoes.Entity.idPool": Entity.idPool
+			"echoes.Entity.idPool": Entity.idPool,
+			"echoes.Entity.nextID": Entity.nextID
 		};
 		
 		for(storage in componentStorage) {
@@ -266,6 +267,7 @@ class Echoes {
 			_activeEntities.push(entity);
 		}
 		
+		Entity.nextID = Reflect.field(data, "echoes.Entity.nextID");
 		Entity.idPool.resize(0);
 		for(id in (Reflect.field(data, "echoes.Entity.idPool"):Array<Int>)) {
 			Entity.idPool.push(id);

--- a/src/echoes/Echoes.hx
+++ b/src/echoes/Echoes.hx
@@ -231,7 +231,7 @@ class Echoes {
 		final data:Dynamic = {
 			"echoes.Echoes.activeEntities": activeEntities,
 			"echoes.Entity.idPool": Entity.idPool,
-			"echoes.Entity.nextID": Entity.nextID
+			"echoes.Entity.nextId": Entity.nextId
 		};
 		
 		for(storage in componentStorage) {
@@ -270,7 +270,7 @@ class Echoes {
 			_activeEntities.push(entity);
 		}
 		
-		Entity.nextID = Reflect.field(data, "echoes.Entity.nextID");
+		Entity.nextId = Reflect.field(data, "echoes.Entity.nextId");
 		Entity.idPool.resize(0);
 		for(id in (Reflect.field(data, "echoes.Entity.idPool"):Array<Int>)) {
 			Entity.idPool.push(id);

--- a/test/EdgeCaseTest.hx
+++ b/test/EdgeCaseTest.hx
@@ -87,7 +87,7 @@ class EdgeCaseTest extends Test {
 	private function testEntityIDSerialization():Void {
 		final entity0:Entity = new Entity();
 		new Entity();
-		Assert.equals(2, Entity.nextID);
+		Assert.equals(2, Entity.nextId);
 		Assert.same([], Entity.idPool);
 		
 		final savedData = Echoes.serialize();
@@ -97,7 +97,7 @@ class EdgeCaseTest extends Test {
 		
 		Echoes.unserialize(savedData);
 		Assert.same([0], Entity.idPool);
-		Assert.equals(2, Entity.nextID);
+		Assert.equals(2, Entity.nextId);
 		Assert.same([1], Echoes.activeEntities);
 	}
 	

--- a/test/EdgeCaseTest.hx
+++ b/test/EdgeCaseTest.hx
@@ -354,6 +354,18 @@ class EdgeCaseTest extends Test {
 		Assert.equals(infos, entity.get(haxe.PosInfos));
 		Assert.equals(infos, entity.get(infos));
 	}
+
+	private function testDestroyWithSerialization():Void {
+		final entity:Entity = new Entity();
+		final savedData = Echoes.serialize();
+		entity.destroy();
+		Echoes.unserialize(savedData);
+		entity.destroy();
+
+		final entity1:Entity = new Entity();
+		final entity2:Entity = new Entity();
+		Assert.notEquals(entity1.id, entity2.id);
+	}
 }
 
 typedef One = Int;

--- a/test/EdgeCaseTest.hx
+++ b/test/EdgeCaseTest.hx
@@ -83,6 +83,24 @@ class EdgeCaseTest extends Test {
 		assertTimesCalled(2, "ComponentsExistSystem.nameRemoved");
 	}
 	
+	@:access(echoes.Entity)
+	private function testEntityIDSerialization():Void {
+		final entity0:Entity = new Entity();
+		new Entity();
+		Assert.equals(2, Entity.nextID);
+		Assert.same([], Entity.idPool);
+		
+		final savedData = Echoes.serialize();
+		entity0.destroy();
+		Assert.same([0], Entity.idPool);
+		Assert.same([1], Echoes.activeEntities);
+		
+		Echoes.unserialize(savedData);
+		Assert.same([0], Entity.idPool);
+		Assert.equals(2, Entity.nextID);
+		Assert.same([1], Echoes.activeEntities);
+	}
+	
 	private function testEntityIndices():Void {
 		inline function assertOrder(order:Array<Entity>, ?posInfos:PosInfos):Void {
 			if(Assert.equals(order.length, Echoes.activeEntities.length, posInfos)) {
@@ -353,18 +371,6 @@ class EdgeCaseTest extends Test {
 		Assert.equals(infos, entity.get(PosInfos));
 		Assert.equals(infos, entity.get(haxe.PosInfos));
 		Assert.equals(infos, entity.get(infos));
-	}
-
-	private function testDestroyWithSerialization():Void {
-		final entity:Entity = new Entity();
-		final savedData = Echoes.serialize();
-		entity.destroy();
-		Echoes.unserialize(savedData);
-		entity.destroy();
-
-		final entity1:Entity = new Entity();
-		final entity2:Entity = new Entity();
-		Assert.notEquals(entity1.id, entity2.id);
 	}
 }
 

--- a/test/EdgeCaseTest.hx
+++ b/test/EdgeCaseTest.hx
@@ -86,19 +86,24 @@ class EdgeCaseTest extends Test {
 	@:access(echoes.Entity)
 	private function testEntityIDSerialization():Void {
 		final entity0:Entity = new Entity();
-		new Entity();
-		Assert.equals(2, Entity.nextId);
-		Assert.same([], Entity.idPool);
+		final entity1:Entity = new Entity();
+		final entity2:Entity = new Entity();
 		
-		final savedData = Echoes.serialize();
+		entity1.destroy();
+		Assert.equals(3, Entity.nextId);
+		Assert.same([1], Entity.idPool);
+		Assert.same([0, 2], Echoes.activeEntities);
+		
+		final savedData:String = Echoes.serialize();
+		
 		entity0.destroy();
-		Assert.same([0], Entity.idPool);
-		Assert.same([1], Echoes.activeEntities);
+		Assert.same([1, 0], Entity.idPool);
+		Assert.same([2], Echoes.activeEntities);
 		
 		Echoes.unserialize(savedData);
-		Assert.same([0], Entity.idPool);
-		Assert.equals(2, Entity.nextId);
-		Assert.same([1], Echoes.activeEntities);
+		Assert.equals(3, Entity.nextId);
+		Assert.same([1], Entity.idPool);
+		Assert.same([0, 2], Echoes.activeEntities);
 	}
 	
 	private function testEntityIndices():Void {


### PR DESCRIPTION
Currently, the following test code fails:
```haxe
final entity = new Entity();
final savedData = Echoes.serialize();
entity.destroy(); // after this, idPool will be [0]
Echoes.unserialize(savedData); // after this, idPool will still be [0]
entity.destroy(); // after this, idPool will be [0, 0] (duplicate entry!)

// then, entity1 and entity2 will have the same ID
// thus the following test fails.
final entity1 = new Entity();
final entity2 = new Entity();
Assert.notEquals(entity1.id, entity2.id);
```

I see three solutions to this problem:
1. Clear `idPool` after unserialization (but this will make it so certain IDs will go unused)
2. When destroying an entity, check through the list or a Map to ensure the ID doesn't already exist before adding it. (possibly unoptimal)
3. Serialize idPool on `Echoes.serialize()`, and restore it on `Echoes.unserialize()`

This PR implements the third solution, and also adds a test case for the problem.