### PR TITLE
Dedicated "Ticks" type for duration

### DIFF
--- a/src/echoes/ComponentStorage.hx
+++ b/src/echoes/ComponentStorage.hx
@@ -85,7 +85,7 @@ class ComponentStorage<T> {
 		#end
 	}
 	
-	public function add(entity:Entity, component:T):Void {
+	public function add(entity:Entity, component:Null<T>):Void {
 		if(component == null) {
 			remove(entity);
 			return;

--- a/src/echoes/Echoes.hx
+++ b/src/echoes/Echoes.hx
@@ -4,6 +4,7 @@ import echoes.ComponentStorage;
 import echoes.Entity;
 import echoes.utils.Clock;
 import echoes.utils.ReadOnlyData;
+import echoes.Ticks;
 import echoes.View;
 import haxe.Serializer;
 import haxe.Unserializer;
@@ -73,7 +74,7 @@ class Echoes {
 	public static final activeSystems:SystemList = {
 		final activeSystems:SystemList = new SystemList();
 		activeSystems.__activate__();
-		activeSystems.clock.maxTime = 1;
+		activeSystems.clock.maxTime = Ticks.fromMilliseconds(1000000);
 		activeSystems;
 	};
 	
@@ -88,18 +89,21 @@ class Echoes {
 	}
 	
 	#if echoes_profiling
-	private static var lastUpdateLength:Int = 0;
+	private static var lastUpdateLength:Ticks = Ticks.ZERO;
 	#end
 	
-	private static var lastUpdate:Float = haxe.Timer.stamp();
+	#if !echoes_no_timer
+	private static var lastUpdate:Ticks = Ticks.now();
 	private static var updateTimer:haxe.Timer;
+	#end
 	
+	#if !echoes_no_timer
 	/**
 	 * @param fps The number of updates to perform each second. If this is zero,
 	 * you will need to call `Echoes.update()` yourself.
 	 */
 	public static function init(?fps:Float = 60):Void {
-		lastUpdate = haxe.Timer.stamp();
+		lastUpdate = Ticks.now();
 		
 		if(updateTimer != null) {
 			updateTimer.stop();
@@ -110,6 +114,7 @@ class Echoes {
 			updateTimer.run = update;
 		}
 	}
+	#end
 	
 	/**
 	 * Returns statistics about the app in JSON-compatible form.
@@ -130,17 +135,23 @@ class Echoes {
 	/**
 	 * Updates all active systems.
 	 */
+	#if !echoes_no_timer
 	public static function update():Void {
-		final startTime:Float = haxe.Timer.stamp();
-		final dt:Float = startTime - lastUpdate;
+		final startTime:Ticks = Ticks.now();
+		final dt:Ticks = startTime - lastUpdate;
 		lastUpdate = startTime;
 		
 		activeSystems.__update__(dt);
 		
 		#if echoes_profiling
-		lastUpdateLength = Std.int((haxe.Timer.stamp() - startTime) * 1000);
+		lastUpdateLength = Ticks.now() - startTime;
 		#end
 	}
+	#else
+	public static function update(dt: Ticks):Void {
+		activeSystems.__update__(dt);
+	}
+	#end
 	
 	/**
 	 * Deactivates all views and systems, destroys all entities, and cancels the
@@ -165,7 +176,9 @@ class Echoes {
 		Entity.idPool.resize(0);
 		Entity.nextId = 0;
 		
+	#if !echoes_no_timer
 		init(0);
+	#end
 	}
 	
 	//Singleton getters
@@ -285,6 +298,6 @@ typedef SystemDetails = {
 	var name:String;
 	@:optional var children:Array<SystemDetails>;
 	#if echoes_profiling
-	var deltaTime:Int;
+	var deltaTime:Ticks;
 	#end
 };

--- a/src/echoes/Entity.hx
+++ b/src/echoes/Entity.hx
@@ -41,9 +41,9 @@ using Lambda;
  * //trace(entity.exists(Array<String>)); //syntax error
  * trace(entity.exists((_:Array<String>))); //true
  * 
- * //`Float` and `Entity` are reserved. To use them as components, you must
+ * //`Ticks` and `Entity` are reserved. To use them as components, you must
  * //first wrap them in a `typedef` or `abstract`.
- * typedef MyFloat = Float;
+ * typedef MyFloat = Ticks;
  * entity.add((1.1:MyFloat));
  * 
  * abstract MyEntity(Entity) from Entity to Entity { }

--- a/src/echoes/System.hx
+++ b/src/echoes/System.hx
@@ -68,12 +68,12 @@ import haxe.rtti.Meta;
 #end
 class System {
 	#if echoes_profiling
-	@:noCompletion private var __updateTime__:Int = 0;
+	@:noCompletion private var __updateTime__:Ticks = Ticks.ZERO;
 	#end
 	
 	@:noCompletion private final __children__:Array<ChildSystem> = [];
 	
-	@:noCompletion private var __dt__:Float = 0;
+	@:noCompletion private var __dt__:Ticks = Ticks.ZERO;
 	
 	public var active(default, null):Bool = false;
 	
@@ -122,7 +122,7 @@ class System {
 	private function __activate__():Void {
 		if(!active) {
 			active = true;
-			__dt__ = 0;
+			__dt__ = Ticks.ZERO;
 			
 			#if !macro
 			onActivate.dispatch();
@@ -131,7 +131,7 @@ class System {
 	}
 	
 	@:noCompletion
-	private inline function __addListenersWithPriority__(priority:Int, runUpdateListeners:(Float) -> Void):Void {
+	private inline function __addListenersWithPriority__(priority:Int, runUpdateListeners:(Ticks) -> Void):Void {
 		__children__.push(new ChildSystem(this, priority, runUpdateListeners));
 	}
 	
@@ -154,7 +154,7 @@ class System {
 	}
 	
 	@:allow(echoes.Echoes)
-	private function __update__(dt:Float):Void {
+	private function __update__(dt:Ticks):Void {
 		__dt__ = dt;
 		
 		//Everything else is handled by macro.
@@ -216,24 +216,24 @@ class System {
 private class ChildSystem extends System {
 	private final parentSystem:System;
 	
-	private final runUpdateListeners:(Float) -> Void;
+	private final runUpdateListeners:(Ticks) -> Void;
 	
-	public inline function new(parentSystem:System, priority:Int, runUpdateListeners:(Float) -> Void) {
+	public inline function new(parentSystem:System, priority:Int, runUpdateListeners:(Ticks) -> Void) {
 		super(priority);
 		
 		this.parentSystem = parentSystem;
 		this.runUpdateListeners = runUpdateListeners;
 	}
 	
-	private override function __update__(dt:Float):Void {
+	private override function __update__(dt:Ticks):Void {
 		#if echoes_profiling
-		final __timestamp__ = Date.now().getTime();
+		final __timestamp__ = Ticks.now();
 		#end
 		
 		runUpdateListeners(dt);
 		
 		#if echoes_profiling
-		this.__updateTime__ = Std.int(Date.now().getTime() - __timestamp__);
+		this.__updateTime__ = Ticks.now() - __timestamp__;
 		#end
 	}
 	

--- a/src/echoes/SystemList.hx
+++ b/src/echoes/SystemList.hx
@@ -78,9 +78,9 @@ class SystemList extends System {
 		}
 	}
 	
-	private override function __update__(dt:Float):Void {
+	private override function __update__(dt:Ticks):Void {
 		#if echoes_profiling
-		final startTime:Float = haxe.Timer.stamp();
+		final startTime:Ticks = Ticks.now();
 		#end
 		
 		__dt__ = dt;
@@ -92,7 +92,7 @@ class SystemList extends System {
 		}
 		
 		#if echoes_profiling
-		__updateTime__ = Std.int((haxe.Timer.stamp() - startTime) * 1000);
+		__updateTime__ = Ticks.now() - startTime;
 		#end
 	}
 	

--- a/src/echoes/Ticks.hx
+++ b/src/echoes/Ticks.hx
@@ -1,0 +1,36 @@
+package echoes;
+
+abstract Ticks(haxe.Int32) {
+    public static inline final MAX: Ticks = cast 1 << 30;
+    public static inline final ONE: Ticks = cast 1;
+    public static inline final ZERO: Ticks = cast 0;
+
+    public var ms(get, never): haxe.Int32;
+
+    public static function fromMilliseconds(ms: haxe.Int32): Ticks
+        return cast ms;
+
+	#if !echoes_no_timer
+    public static function now(): Ticks
+        return fromMilliseconds(cast haxe.Timer.stamp() * 1000);
+    #end
+
+    @:op(this + rhs)
+    public function add(rhs: Ticks): Ticks
+        return cast this + cast rhs;
+
+    @:op(this - rhs)
+    public function diff(rhs: Ticks): Ticks
+        return cast this - cast rhs;
+
+    @:op(this * rhs)
+    public function mult(rhs: Float): Ticks
+        return cast this * rhs;
+
+    @:op(this > rhs)
+    public function greater(rhs: Ticks): Bool
+        return cast this > cast rhs;
+
+    public function get_ms(): haxe.Int32
+        return cast this;
+}

--- a/src/echoes/macro/EntityTemplateBuilder.hx
+++ b/src/echoes/macro/EntityTemplateBuilder.hx
@@ -274,8 +274,8 @@ class EntityTemplateBuilder {
 			switch(componentType) {
 				case macro:Entity, macro:echoes.Entity:
 					Context.fatalError("Entity is reserved. Consider using a typedef, abstract, or Int", field.pos);
-				case macro:Float, macro:StdTypes.Float:
-					Context.fatalError("Float is reserved for lengths of time. Consider using a typedef or abstract", field.pos);
+				case macro:Ticks, macro:echoes.Ticks:
+					Context.fatalError("Ticks is reserved for lengths of time. Consider using a typedef or abstract", field.pos);
 				default:
 			}
 			

--- a/src/echoes/macro/EntityTools.hx
+++ b/src/echoes/macro/EntityTools.hx
@@ -31,8 +31,7 @@ class EntityTools {
 			
 			$b{ [for(component in components) {
 				final type:Type = component.parseComponentType();
-				
-				final operation:String = switch(type) {
+				final operation:String = switch(@:nullSafety(Off) type) {
 					case TEnum(_.get().meta => m, _),
 						TInst(_.get().meta => m, _),
 						TType(_.get().meta => m, _),

--- a/src/echoes/macro/MacroTools.hx
+++ b/src/echoes/macro/MacroTools.hx
@@ -99,8 +99,8 @@ class MacroTools {
 		return switch(type) {
 			case TPath({ pack: [] | ["echoes"], name: "Entity"}):
 				"Entity is not an allowed component type. Try using a typedef, an abstract, or Int instead.";
-			case TPath({ pack: [], name: "Float" } | { name: "StdTypes", sub: "Float" }):
-				"Float is not an allowed component type. Try using a typedef or an abstract instead.";
+			case TPath({ pack: [] | ["echoes"], name: "Ticks"}):
+				"Ticks is not an allowed component type. Try using a typedef or an abstract instead.";
 			default:
 				null;
 		};

--- a/src/echoes/macro/SystemBuilder.hx
+++ b/src/echoes/macro/SystemBuilder.hx
@@ -245,7 +245,7 @@ class SystemBuilder {
 			final body:Array<Expr> = [for(listener in listeners) listener.callDuringUpdate()];
 			body.unshift(macro __dt__ = dt);
 			
-			macro __addListenersWithPriority__(${ knownPriorities[priority] }, function(dt:Float) $b{ body });
+			macro __addListenersWithPriority__(${ knownPriorities[priority] }, function(dt:Ticks) $b{ body });
 		}];
 		initializeChildren.push(macro if(parent != null) {
 			for(child in __children__) {
@@ -334,9 +334,9 @@ class SystemBuilder {
 				}
 			}
 			
-			private override function __update__(dt:Float):Void {
+			private override function __update__(dt:echoes.Ticks):Void {
 				#if echoes_profiling
-				final __timestamp__ = Date.now().getTime();
+				final __timestamp__ = Ticks.now();
 				#end
 				
 				${ if(parentTypes.length <= 2) {
@@ -364,7 +364,7 @@ class SystemBuilder {
 				} } */
 				
 				#if echoes_profiling
-				this.__updateTime__ = Std.int(Date.now().getTime() - __timestamp__);
+				this.__updateTime__ = Ticks.now() - __timestamp__;
 				#end
 			}
 		};
@@ -470,7 +470,7 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 			//Find non-optional, non-reserved arguments.
 			for(arg in this.args) {
 				switch(arg.type.followComplexType()) {
-					case macro:StdTypes.Float, macro:echoes.Entity:
+					case macro:echoes.Ticks, macro:echoes.Entity:
 					case type if(!arg.opt && arg.value == null):
 						this.components.push(type);
 					default:
@@ -494,7 +494,7 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 			//Find optional, non-reserved arguments.
 			for(arg in this.args) {
 				switch(arg.type.followComplexType()) {
-					case macro:StdTypes.Float, macro:echoes.Entity:
+					case macro:echoes.Ticks, macro:echoes.Entity:
 					case type if(arg.opt || arg.value != null):
 						this.optionalComponents.push(type);
 					default:
@@ -578,7 +578,7 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 	private function call(getEntity:Expr, getDeltaTime:Expr):Expr {
 		final args:Array<Expr> = [for(arg in this.args) {
 			switch(arg.type.followComplexType()) {
-				case macro:StdTypes.Float:
+				case macro:echoes.Ticks:
 					//Defined as a private variable of `System`.
 					getDeltaTime;
 				case macro:echoes.Entity:
@@ -611,7 +611,7 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 				${ call(macro entity, macro __dt__) };
 		} else {
 			//No components to filter by, but there may still be an `Entity`
-			//argument. (And/or a `Float` argument, which isn't relevant.)
+			//argument. (And/or a `Ticks` argument, which isn't relevant.)
 			for(arg in this.args) {
 				if(arg.type.followComplexType().match(macro:echoes.Entity)) {
 					//Iterate over all entities.

--- a/src/echoes/macro/TypeSubstitutions.hx
+++ b/src/echoes/macro/TypeSubstitutions.hx
@@ -119,7 +119,7 @@ class TypeSubstitutions {
 			final type:ComplexType = types[i].followMono().toComplexType();
 			addSubstitution(param.name, type);
 			
-			//Check for `Entity` and `Float`.
+			//Check for `Entity` and `Ticks`.
 			final error:String = type.getReservedComponentMessage();
 			if(error != null && !codeCompletionMode) {
 				Context.error('$className.${ param.name }: ' + error, Context.currentPos());

--- a/src/echoes/macro/ViewBuilder.hx
+++ b/src/echoes/macro/ViewBuilder.hx
@@ -208,7 +208,7 @@ class ViewBuilder {
 		final requiredComponents:Array<ComplexType> = [];
 		final funcArgs:Array<Expr> = [for(arg in args) {
 			switch(arg.type.followComplexType()) {
-				case macro:StdTypes.Float:
+				case macro:echoes.Ticks:
 					getDeltaTime;
 				case macro:echoes.Entity:
 					macro entity;
@@ -225,7 +225,7 @@ class ViewBuilder {
 			final entities:haxe.ds.ReadOnlyArray<echoes.Entity> = $i{ getViewName(requiredComponents) }.instance.entities;
 			while(i < entities.length) {
 				final entity:echoes.Entity = entities[i];
-				$func($a{ funcArgs });
+				@:nullSafety(Off) $func($a{ funcArgs });
 				
 				if(entity != entities[i] && !entities.contains(entity)) {
 					//Entity was removed; don't increment.

--- a/src/echoes/utils/Clock.hx
+++ b/src/echoes/utils/Clock.hx
@@ -44,12 +44,12 @@ class Clock {
 	 * Setting `minTickLength` and `maxTickLength` to the same value creates a
 	 * fixed tick length.
 	 */
-	public var maxTickLength:Float = Math.POSITIVE_INFINITY;
+	public var maxTickLength:Ticks = Ticks.MAX;
 	
 	/**
 	 * `time` will be capped to this value.
 	 */
-	public var maxTime:Float = Math.POSITIVE_INFINITY;
+	public var maxTime:Ticks = Ticks.MAX;
 	
 	/**
 	 * Once `time` falls below this value, the `Clock` will stop ticking. Any
@@ -58,7 +58,7 @@ class Clock {
 	 * Setting `minTickLength` and `maxTickLength` to the same value creates a
 	 * fixed tick length.
 	 */
-	public var minTickLength:Float = 1e-16;
+	public var minTickLength:Ticks = Ticks.ONE;
 	
 	/**
 	 * Prevents `time` from increasing, but doesn't prevent iterating over
@@ -72,12 +72,12 @@ class Clock {
 	public var tickCount:Int = 0;
 	
 	/**
-	 * The amount of time left on the `Clock`, in seconds.
+	 * The amount of time left on the `Clock`, in ticks.
 	 * 
 	 * To calculate [the blending factor](https://www.gafferongames.com/post/fix_your_timestep/#the-final-touch)
 	 * described in "Fix Your Timestep!", divide `time` by `minTickLength`.
 	 */
-	public var time(default, null):Float = 0;
+	public var time(default, null):Ticks = Ticks.ZERO;
 	
 	/**
 	 * Multiplies all added time. This can speed time up (if `timeScale > 1`),
@@ -88,7 +88,7 @@ class Clock {
 	public inline function new() {
 	}
 	
-	public function addTime(time:Float):Void {
+	public function addTime(time:Ticks):Void {
 		if(!paused) {
 			this.time += time * timeScale;
 			
@@ -101,11 +101,11 @@ class Clock {
 	}
 	
 	public inline function hasNext():Bool {
-		return time >= minTickLength;
+		return !(minTickLength > time);
 	}
 	
-	public function next():Float {
-		final tick:Float = time > maxTickLength ? maxTickLength : time;
+	public function next():Ticks {
+		final tick:Ticks = time > maxTickLength ? maxTickLength : time;
 		time -= tick;
 		tickCount++;
 		return tick;
@@ -115,7 +115,7 @@ class Clock {
 	 * Sets `minTickLength` and `maxTickLength` to the given value, ensuring
 	 * that every time this clock ticks, the tick will be the same length.
 	 */
-	public inline function setFixedTickLength(fixedTickLength:Float):Void {
+	public inline function setFixedTickLength(fixedTickLength:Ticks):Void {
 		minTickLength = maxTickLength = fixedTickLength;
 	}
 }

--- a/test/AdvancedFunctionalityTest.hx
+++ b/test/AdvancedFunctionalityTest.hx
@@ -6,6 +6,7 @@ import echoes.Echoes;
 import echoes.Entity;
 import echoes.System;
 import echoes.SystemList;
+import echoes.Ticks;
 import echoes.utils.ComponentTypes;
 import echoes.utils.Signal;
 import echoes.View;
@@ -258,7 +259,7 @@ class AdvancedFunctionalityTest extends Test {
 		final updateOrder:Array<String> = [];
 		new Entity(true).add(updateOrder);
 		list.__activate__();
-		list.__update__(1);
+		list.__update__(Ticks.fromMilliseconds(1));
 		Assert.equals("pre_update, update, update2, post_update", updateOrder.join(", "));
 		
 		//Update the priority of existing systems. Setting `low` to -1 should
@@ -273,7 +274,7 @@ class AdvancedFunctionalityTest extends Test {
 		]);
 		
 		updateOrder.resize(0);
-		list.__update__(1);
+		list.__update__(Ticks.ONE);
 		Assert.equals("update, update2, pre_update, post_update", updateOrder.join(", "));
 	}
 	

--- a/test/BasicFunctionalityTest.hx
+++ b/test/BasicFunctionalityTest.hx
@@ -4,6 +4,7 @@ import Components;
 import echoes.Echoes;
 import echoes.Entity;
 import echoes.SystemList;
+import echoes.Ticks;
 import echoes.utils.Clock;
 import MethodCounter.assertTimesCalled;
 import Systems;
@@ -265,7 +266,7 @@ class BasicFunctionalityTest extends Test {
 		star.add((0xFFFFFF:Color));
 
 		//Simulate time passing without actually waiting for it.
-		Echoes.lastUpdate -= 0.001;
+		Echoes.lastUpdate -= Ticks.ONE;
 		
 		//Run another few updates. (`colorTime` should now increment twice per
 		//update, since now two entities have color.)
@@ -275,7 +276,7 @@ class BasicFunctionalityTest extends Test {
 		Assert.equals(2.0, timeCountSystem.shapeTime);
 		Assert.equals(1.0, timeCountSystem.colorAndShapeTime);
 		
-		Echoes.lastUpdate -= 0.001;
+		Echoes.lastUpdate -= Ticks.ONE;
 		Echoes.update();
 		Assert.equals(3.0, timeCountSystem.totalTime);
 		Assert.equals(5.0, timeCountSystem.colorTime);
@@ -289,7 +290,7 @@ class BasicFunctionalityTest extends Test {
  * regardless of the real-world time elapsed.
  */
 class OneSecondClock extends Clock {
-	public override function addTime(time:Float):Void {
-		super.addTime(1);
+	public override function addTime(time:Ticks):Void {
+		super.addTime(Ticks.fromMilliseconds(1000));
 	}
 }

--- a/test/Systems.hx
+++ b/test/Systems.hx
@@ -3,6 +3,7 @@ package;
 import Components;
 import echoes.Entity;
 import echoes.System;
+import echoes.Ticks;
 import haxe.extern.EitherType;
 import MethodCounter;
 
@@ -56,24 +57,24 @@ class OptionalComponentSystem extends System implements IMethodCounter {
 }
 
 class TimeCountSystem extends System implements IMethodCounter {
-	public var colorTime:Float = 0;
-	public var shapeTime:Float = 0;
-	public var colorAndShapeTime:Float = 0;
-	public var totalTime:Float = 0;
+	public var colorTime:Ticks = Ticks.ZERO;
+	public var shapeTime:Ticks = Ticks.ZERO;
+	public var colorAndShapeTime:Ticks = Ticks.ZERO;
+	public var totalTime:Ticks = Ticks.ZERO;
 	
-	@:update private function colorUpdated(color:Color, time:Float):Void {
+	@:update private function colorUpdated(color:Color, time:Ticks):Void {
 		colorTime += time;
 	}
 	
-	@:update private function shapeUpdated(shape:Shape, time:Float):Void {
+	@:update private function shapeUpdated(shape:Shape, time:Ticks):Void {
 		shapeTime += time;
 	}
 	
-	@:update private function colorAndShapeUpdated(color:Color, shape:Shape, time:Float):Void {
+	@:update private function colorAndShapeUpdated(color:Color, shape:Shape, time:Ticks):Void {
 		colorAndShapeTime += time;
 	}
 	
-	@:update private function update(time:Float):Void {
+	@:update private function update(time:Ticks):Void {
 		totalTime += time;
 	}
 }


### PR DESCRIPTION
The new ``Ticks`` type is an integer number of milliseconds.
The ``echoes_no_timer`` compiler flag can be used to disable calls to ``haxe.Timer``.  

The motivation of this is that I'm developing for the Panic Playdate console, which has limited support for timers and low performances with 64-bit float.