### PR TITLE
Implement an option for millisecond time.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,6 @@ jobs:
       
       - name: Run tests (stable array order)
         run: haxe tests.hxml --interp -D echoes_stable_order
+      
+      - name: Run tests (millisecond timing)
+        run: haxe tests.hxml --interp -D echoes_custom_time=milliseconds

--- a/src/echoes/Echoes.hx
+++ b/src/echoes/Echoes.hx
@@ -91,7 +91,7 @@ class Echoes {
 	private static var lastUpdateLength:Int = 0;
 	#end
 	
-	private static var lastUpdate:Float = haxe.Timer.stamp();
+	private static var lastUpdate:Time = Time.stamp();
 	private static var updateTimer:haxe.Timer;
 	
 	/**
@@ -99,7 +99,7 @@ class Echoes {
 	 * you will need to call `Echoes.update()` yourself.
 	 */
 	public static function init(?fps:Float = 60):Void {
-		lastUpdate = haxe.Timer.stamp();
+		lastUpdate = Time.stamp();
 		
 		if(updateTimer != null) {
 			updateTimer.stop();
@@ -131,14 +131,14 @@ class Echoes {
 	 * Updates all active systems.
 	 */
 	public static function update():Void {
-		final startTime:Float = haxe.Timer.stamp();
-		final dt:Float = startTime - lastUpdate;
+		final startTime:Time = Time.stamp();
+		final dt:Time = startTime - lastUpdate;
 		lastUpdate = startTime;
 		
 		activeSystems.__update__(dt);
 		
 		#if echoes_profiling
-		lastUpdateLength = Std.int((haxe.Timer.stamp() - startTime) * 1000);
+		lastUpdateLength = (Time.stamp() - startTime).toMilliseconds();
 		#end
 	}
 	

--- a/src/echoes/System.hx
+++ b/src/echoes/System.hx
@@ -73,7 +73,7 @@ class System {
 	
 	@:noCompletion private final __children__:Array<ChildSystem> = [];
 	
-	@:noCompletion private var __dt__:Float = 0;
+	@:noCompletion private var __dt__:Time = 0;
 	
 	public var active(default, null):Bool = false;
 	
@@ -131,7 +131,7 @@ class System {
 	}
 	
 	@:noCompletion
-	private inline function __addListenersWithPriority__(priority:Int, runUpdateListeners:(Float) -> Void):Void {
+	private inline function __addListenersWithPriority__(priority:Int, runUpdateListeners:(Time) -> Void):Void {
 		__children__.push(new ChildSystem(this, priority, runUpdateListeners));
 	}
 	
@@ -154,7 +154,7 @@ class System {
 	}
 	
 	@:allow(echoes.Echoes)
-	private function __update__(dt:Float):Void {
+	private function __update__(dt:Time):Void {
 		__dt__ = dt;
 		
 		//Everything else is handled by macro.
@@ -216,16 +216,16 @@ class System {
 private class ChildSystem extends System {
 	private final parentSystem:System;
 	
-	private final runUpdateListeners:(Float) -> Void;
+	private final runUpdateListeners:(Time) -> Void;
 	
-	public inline function new(parentSystem:System, priority:Int, runUpdateListeners:(Float) -> Void) {
+	public inline function new(parentSystem:System, priority:Int, runUpdateListeners:(Time) -> Void) {
 		super(priority);
 		
 		this.parentSystem = parentSystem;
 		this.runUpdateListeners = runUpdateListeners;
 	}
 	
-	private override function __update__(dt:Float):Void {
+	private override function __update__(dt:Time):Void {
 		#if echoes_profiling
 		final __timestamp__ = Date.now().getTime();
 		#end

--- a/src/echoes/SystemList.hx
+++ b/src/echoes/SystemList.hx
@@ -78,9 +78,9 @@ class SystemList extends System {
 		}
 	}
 	
-	private override function __update__(dt:Float):Void {
+	private override function __update__(dt:Time):Void {
 		#if echoes_profiling
-		final startTime:Float = haxe.Timer.stamp();
+		final startTime:Time = Time.stamp();
 		#end
 		
 		__dt__ = dt;
@@ -92,7 +92,7 @@ class SystemList extends System {
 		}
 		
 		#if echoes_profiling
-		__updateTime__ = Std.int((haxe.Timer.stamp() - startTime) * 1000);
+		__updateTime__ = (Time.stamp() - startTime).toMilliseconds();
 		#end
 	}
 	

--- a/src/echoes/Time.hx
+++ b/src/echoes/Time.hx
@@ -1,0 +1,103 @@
+package echoes;
+
+import haxe.Timer;
+
+#if !echoes_millisecond_time
+
+/**
+ * An amount of time, in seconds.
+ * 
+ * In `@:update` functions, a `Time` or `Float` argument (the two are fully
+ * interchangeable) has a special meaning: instead of getting the value of a
+ * component, it gets the length of the update.
+ * @see `echoes.utils.Clock`
+ */
+@:eager abstract Time(Float) from Float to Float {
+	public static var MAX(get, never):Time;
+	private static inline function get_MAX():Time {
+		return Math.POSITIVE_INFINITY;
+	}
+	
+	//Large enough to reliably avoid rounding. Not the true minimum.
+	public static inline final MIN_POSITIVE:Time = 1e-16;
+	
+	public static inline function fromMilliseconds(milliseconds:Int):Time {
+		return milliseconds / 1000;
+	}
+	
+	public static inline function stamp():Time {
+		return Timer.stamp();
+	}
+	
+	public inline function toMilliseconds():Int {
+		return Std.int(this * 1000);
+	}
+	
+	@:op(A + B) private function sum(b:Time):Time;
+	@:op(A += B) private inline function add(b:Time):Time {
+		return this += (b:Float);
+	}
+	@:op(A - B) private function difference(b:Time):Time;
+	@:op(A -= B) private inline function subtract(b:Time):Time {
+		return this -= (b:Float);
+	}
+	@:op(A * B) private function product(b:Time):Time;
+	@:op(A *= B) private inline function quotient(b:Time):Time {
+		return this *= (b:Float);
+	}
+	
+	@:op(A > B) private function greater(b:Time):Bool;
+	@:op(A >= B) private function greaterEqual(b:Time):Bool;
+	@:op(A < B) private function less(b:Time):Bool;
+	@:op(A <= B) private function lessEqual(b:Time):Bool;
+	@:op(A != B) private function notEqual(b:Time):Bool;
+}
+
+#else
+
+/**
+ * An amount of time, in milliseconds.
+ * 
+ * In `@:update` functions, a `Time` argument has a special meaning: instead of
+ * getting the value of a component, it gets the length of the update.
+ * 
+ * To use this version of `Time`, set `-D echoes_millisecond_time`.
+ * @see `echoes.utils.Clock`
+ */
+abstract Time(Int) from Int to Int {
+	public static inline final MAX:Time = 0x7FFFFFFF;
+	public static inline final MIN_POSITIVE:Time = 1;
+	
+	public static inline function fromMilliseconds(milliseconds:Int):Time {
+		return milliseconds;
+	}
+	
+	public static inline function stamp():Time {
+		return Std.int(Timer.stamp() * 1000);
+	}
+	
+	public inline function toMilliseconds():Int {
+		return this;
+	}
+	
+	@:op(A + B) private function sum(b:Time):Time;
+	@:op(A += B) private inline function add(b:Time):Time {
+		return this += (b:Int);
+	}
+	@:op(A - B) private function difference(b:Time):Time;
+	@:op(A -= B) private inline function subtract(b:Time):Time {
+		return this -= (b:Int);
+	}
+	@:op(A * B) private function product(b:Time):Time;
+	@:op(A *= B) private inline function quotient(b:Time):Time {
+		return this *= (b:Int);
+	}
+	
+	@:op(A > B) private function greater(b:Time):Bool;
+	@:op(A >= B) private function greaterEqual(b:Time):Bool;
+	@:op(A < B) private function less(b:Time):Bool;
+	@:op(A <= B) private function lessEqual(b:Time):Bool;
+	@:op(A != B) private function notEqual(b:Time):Bool;
+}
+
+#end

--- a/src/echoes/macro/EntityTemplateBuilder.hx
+++ b/src/echoes/macro/EntityTemplateBuilder.hx
@@ -271,12 +271,9 @@ class EntityTemplateBuilder {
 			}
 			
 			//Check for reserved types.
-			switch(componentType) {
-				case macro:Entity, macro:echoes.Entity:
-					Context.fatalError("Entity is reserved. Consider using a typedef, abstract, or Int", field.pos);
-				case macro:Float, macro:StdTypes.Float:
-					Context.fatalError("Float is reserved for lengths of time. Consider using a typedef or abstract", field.pos);
-				default:
+			var reservedMessage:String = componentType.getReservedComponentMessage();
+			if(reservedMessage != null) {
+				Context.fatalError(reservedMessage, field.pos);
 			}
 			
 			//Convert the field to a property, and remove the expression.

--- a/src/echoes/macro/MacroTools.hx
+++ b/src/echoes/macro/MacroTools.hx
@@ -96,14 +96,17 @@ class MacroTools {
 	 * @return An error message if `type` is reserved, or null otherwise.
 	 */
 	public static function getReservedComponentMessage(type:ComplexType):Null<String> {
-		return switch(type) {
-			case TPath({ pack: [] | ["echoes"], name: "Entity"}):
-				"Entity is not an allowed component type. Try using a typedef, an abstract, or Int instead.";
-			case TPath({ pack: [], name: "Float" } | { name: "StdTypes", sub: "Float" }):
-				"Float is not an allowed component type. Try using a typedef or an abstract instead.";
+		switch(type) {
+			case macro:echoes.Entity, macro:echoes.Time:
+				//Error, see below.
+			case macro:StdTypes.Float if(!Context.defined("echoes_millisecond_time")):
+				//Error, see below.
 			default:
-				null;
-		};
+				return null;
+		}
+		
+		return new Printer().printComplexType(type) + " is not an allowed component type. "
+			+ "Try using a typedef or an abstract instead.";
 	}
 	
 	public static inline function isResolvable(p:TypePath):Bool {

--- a/src/echoes/macro/SystemBuilder.hx
+++ b/src/echoes/macro/SystemBuilder.hx
@@ -245,7 +245,7 @@ class SystemBuilder {
 			final body:Array<Expr> = [for(listener in listeners) listener.callDuringUpdate()];
 			body.unshift(macro __dt__ = dt);
 			
-			macro __addListenersWithPriority__(${ knownPriorities[priority] }, function(dt:Float) $b{ body });
+			macro __addListenersWithPriority__(${ knownPriorities[priority] }, function(dt:echoes.Time) $b{ body });
 		}];
 		initializeChildren.push(macro if(parent != null) {
 			for(child in __children__) {
@@ -334,7 +334,7 @@ class SystemBuilder {
 				}
 			}
 			
-			private override function __update__(dt:Float):Void {
+			private override function __update__(dt:echoes.Time):Void {
 				#if echoes_profiling
 				final __timestamp__ = Date.now().getTime();
 				#end
@@ -470,7 +470,8 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 			//Find non-optional, non-reserved arguments.
 			for(arg in this.args) {
 				switch(arg.type.followComplexType()) {
-					case macro:StdTypes.Float, macro:echoes.Entity:
+					case macro:echoes.Entity, macro:echoes.Time:
+					case macro:StdTypes.Float if(!Context.defined("echoes_millisecond_time")):
 					case type if(!arg.opt && arg.value == null):
 						this.components.push(type);
 					default:
@@ -494,7 +495,8 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 			//Find optional, non-reserved arguments.
 			for(arg in this.args) {
 				switch(arg.type.followComplexType()) {
-					case macro:StdTypes.Float, macro:echoes.Entity:
+					case macro:echoes.Entity, macro:echoes.Time:
+					case macro:StdTypes.Float if(!Context.defined("echoes_millisecond_time")):
 					case type if(arg.opt || arg.value != null):
 						this.optionalComponents.push(type);
 					default:
@@ -578,7 +580,10 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 	private function call(getEntity:Expr, getDeltaTime:Expr):Expr {
 		final args:Array<Expr> = [for(arg in this.args) {
 			switch(arg.type.followComplexType()) {
-				case macro:StdTypes.Float:
+				case macro:echoes.Time:
+					//Defined as a private variable of `System`.
+					getDeltaTime;
+				case macro:StdTypes.Float if(!Context.defined("echoes_millisecond_time")):
 					//Defined as a private variable of `System`.
 					getDeltaTime;
 				case macro:echoes.Entity:
@@ -611,7 +616,7 @@ abstract ListenerFunction(ListenerFunctionData) from ListenerFunctionData {
 				${ call(macro entity, macro __dt__) };
 		} else {
 			//No components to filter by, but there may still be an `Entity`
-			//argument. (And/or a `Float` argument, which isn't relevant.)
+			//argument. (And/or a `Time` argument, which isn't relevant.)
 			for(arg in this.args) {
 				if(arg.type.followComplexType().match(macro:echoes.Entity)) {
 					//Iterate over all entities.

--- a/src/echoes/macro/ViewBuilder.hx
+++ b/src/echoes/macro/ViewBuilder.hx
@@ -208,7 +208,9 @@ class ViewBuilder {
 		final requiredComponents:Array<ComplexType> = [];
 		final funcArgs:Array<Expr> = [for(arg in args) {
 			switch(arg.type.followComplexType()) {
-				case macro:StdTypes.Float:
+				case macro:echoes.Time:
+					getDeltaTime;
+				case macro:StdTypes.Float if(!Context.defined("echoes_millisecond_time")):
 					getDeltaTime;
 				case macro:echoes.Entity:
 					macro entity;

--- a/src/echoes/utils/Clock.hx
+++ b/src/echoes/utils/Clock.hx
@@ -1,5 +1,7 @@
 package echoes.utils;
 
+import echoes.Time;
+
 /**
  * A `Clock` determines how to split up chunks of time, allowing you to
  * customize how many times a `SystemList` will update in a row, and the length
@@ -44,12 +46,12 @@ class Clock {
 	 * Setting `minTickLength` and `maxTickLength` to the same value creates a
 	 * fixed tick length.
 	 */
-	public var maxTickLength:Float = Math.POSITIVE_INFINITY;
+	public var maxTickLength:Time = Time.MAX;
 	
 	/**
 	 * `time` will be capped to this value.
 	 */
-	public var maxTime:Float = Math.POSITIVE_INFINITY;
+	public var maxTime:Time = Time.MAX;
 	
 	/**
 	 * Once `time` falls below this value, the `Clock` will stop ticking. Any
@@ -58,7 +60,7 @@ class Clock {
 	 * Setting `minTickLength` and `maxTickLength` to the same value creates a
 	 * fixed tick length.
 	 */
-	public var minTickLength:Float = 1e-16;
+	public var minTickLength:Time = Time.MIN_POSITIVE;
 	
 	/**
 	 * Prevents `time` from increasing, but doesn't prevent iterating over
@@ -77,18 +79,18 @@ class Clock {
 	 * To calculate [the blending factor](https://www.gafferongames.com/post/fix_your_timestep/#the-final-touch)
 	 * described in "Fix Your Timestep!", divide `time` by `minTickLength`.
 	 */
-	public var time(default, null):Float = 0;
+	public var time(default, null):Time = 0;
 	
 	/**
 	 * Multiplies all added time. This can speed time up (if `timeScale > 1`),
 	 * slow it down (if `0 < timeScale < 1`), or pause it (if `timeScale == 0`).
 	 */
-	public var timeScale:Float = 1;
+	public var timeScale:Time = 1;
 	
 	public inline function new() {
 	}
 	
-	public function addTime(time:Float):Void {
+	public function addTime(time:Time):Void {
 		if(!paused) {
 			this.time += time * timeScale;
 			
@@ -101,11 +103,12 @@ class Clock {
 	}
 	
 	public inline function hasNext():Bool {
+		trace('$time >= $minTickLength');
 		return time >= minTickLength;
 	}
 	
-	public function next():Float {
-		final tick:Float = time > maxTickLength ? maxTickLength : time;
+	public function next():Time {
+		final tick:Time = time > maxTickLength ? maxTickLength : time;
 		time -= tick;
 		tickCount++;
 		return tick;
@@ -115,7 +118,7 @@ class Clock {
 	 * Sets `minTickLength` and `maxTickLength` to the given value, ensuring
 	 * that every time this clock ticks, the tick will be the same length.
 	 */
-	public inline function setFixedTickLength(fixedTickLength:Float):Void {
+	public inline function setFixedTickLength(fixedTickLength:Time):Void {
 		minTickLength = maxTickLength = fixedTickLength;
 	}
 }

--- a/test/BasicFunctionalityTest.hx
+++ b/test/BasicFunctionalityTest.hx
@@ -4,6 +4,7 @@ import Components;
 import echoes.Echoes;
 import echoes.Entity;
 import echoes.SystemList;
+import echoes.Time;
 import echoes.utils.Clock;
 import MethodCounter.assertTimesCalled;
 import Systems;
@@ -234,62 +235,44 @@ class BasicFunctionalityTest extends Test {
 		assertTimesCalled(2, "AppearanceSystem.shapeRemoved");
 	}
 	
-	@:access(echoes.Echoes.lastUpdate)
+	@:access(echoes.SystemList.__update__)
 	private function testUpdateEvents():Void {
-		//Create a `TimeCountSystem` and use a custom `Clock`.
-		final systems:SystemList = new SystemList(new OneSecondClock());
-		systems.activate();
-		
 		final timeCountSystem:TimeCountSystem = new TimeCountSystem();
-		Assert.equals(0.0, timeCountSystem.totalTime);
+		Assert.equals((0:Time), timeCountSystem.totalTime);
 		
-		systems.add(timeCountSystem);
+		timeCountSystem.activate();
 		
 		//Create some entities, but none with both color and shape.
 		final green:Entity = new Entity().add((0x00FF00:Color));
-		Assert.equals(0.0, timeCountSystem.colorTime);
+		Assert.equals((0:Time), timeCountSystem.colorTime);
 		
 		final star:Entity = new Entity().add(STAR, ("Proxima Centauri":Name));
-		Assert.equals(0.0, timeCountSystem.shapeTime);
+		Assert.equals((0:Time), timeCountSystem.shapeTime);
 		
 		Assert.isNull(star.get(Color), star.get(Color) + " should be null. See ComponentStorage constructor for details.");
 		
 		//Run an update.
-		Echoes.update();
-		Assert.equals(1.0, timeCountSystem.totalTime);
-		Assert.equals(1.0, timeCountSystem.colorTime);
-		Assert.equals(1.0, timeCountSystem.shapeTime);
-		Assert.equals(0.0, timeCountSystem.colorAndShapeTime);
+		Echoes.activeSystems.__update__(1);
+		Assert.equals((1:Time), timeCountSystem.totalTime);
+		Assert.equals((1:Time), timeCountSystem.colorTime);
+		Assert.equals((1:Time), timeCountSystem.shapeTime);
+		Assert.equals((0:Time), timeCountSystem.colorAndShapeTime);
 		
 		//Give one entity both a color and shape.
 		star.add((0xFFFFFF:Color));
-
-		//Simulate time passing without actually waiting for it.
-		Echoes.lastUpdate -= 0.001;
 		
 		//Run another few updates. (`colorTime` should now increment twice per
 		//update, since now two entities have color.)
-		Echoes.update();
-		Assert.equals(2.0, timeCountSystem.totalTime);
-		Assert.equals(3.0, timeCountSystem.colorTime);
-		Assert.equals(2.0, timeCountSystem.shapeTime);
-		Assert.equals(1.0, timeCountSystem.colorAndShapeTime);
+		Echoes.activeSystems.__update__(1);
+		Assert.equals((2:Time), timeCountSystem.totalTime);
+		Assert.equals((3:Time), timeCountSystem.colorTime);
+		Assert.equals((2:Time), timeCountSystem.shapeTime);
+		Assert.equals((1:Time), timeCountSystem.colorAndShapeTime);
 		
-		Echoes.lastUpdate -= 0.001;
-		Echoes.update();
-		Assert.equals(3.0, timeCountSystem.totalTime);
-		Assert.equals(5.0, timeCountSystem.colorTime);
-		Assert.equals(3.0, timeCountSystem.shapeTime);
-		Assert.equals(2.0, timeCountSystem.colorAndShapeTime);
-	}
-}
-
-/**
- * A custom `Clock` that advances 1 second whenever `Echoes.update()` is called,
- * regardless of the real-world time elapsed.
- */
-class OneSecondClock extends Clock {
-	public override function addTime(time:Float):Void {
-		super.addTime(1);
+		Echoes.activeSystems.__update__(1);
+		Assert.equals((3:Time), timeCountSystem.totalTime);
+		Assert.equals((5:Time), timeCountSystem.colorTime);
+		Assert.equals((3:Time), timeCountSystem.shapeTime);
+		Assert.equals((2:Time), timeCountSystem.colorAndShapeTime);
 	}
 }

--- a/test/EdgeCaseTest.hx
+++ b/test/EdgeCaseTest.hx
@@ -23,20 +23,21 @@ class EdgeCaseTest extends Test {
 	
 	//Tests may be run in any order, but not in parallel.
 	
+	@:access(echoes.SystemList.__update__)
 	private function testAllArgumentsOptional():Void {
 		new OptionalListenerSystem().activate();
-		Echoes.update();
+		Echoes.activeSystems.__update__(1);
 		assertTimesCalled(0, "OptionalListenerSystem.optionalNameUpdated");
 		
 		final entity:Entity = new Entity();
 		entity.add(("name":Name));
-		Echoes.update();
+		Echoes.activeSystems.__update__(1);
 		assertTimesCalled(1, "OptionalListenerSystem.optionalNameUpdated");
 		
 		//When there are multiple entities, the function should be called for
 		//each, whether or not they have `Name` components.
 		new Entity();
-		Echoes.update();
+		Echoes.activeSystems.__update__(1);
 		assertTimesCalled(3, "OptionalListenerSystem.optionalNameUpdated");
 	}
 	
@@ -306,6 +307,7 @@ class EdgeCaseTest extends Test {
 		Assert.equals(80.0, entity.get(Permanent));
 	}
 	
+	@:access(echoes.SystemList.__update__)
 	private function testRemoveDuringUpdate():Void {
 		final system:RemoveStringSystem = new RemoveStringSystem();
 		system.activate();
@@ -318,7 +320,7 @@ class EdgeCaseTest extends Test {
 		entity1.add("keep");
 		Assert.equals(2, Echoes.getView(String).entities.length);
 		
-		Echoes.update();
+		Echoes.activeSystems.__update__(1);
 		assertTimesCalled(2, "RemoveStringSystem.removeString");
 		Assert.equals(1, Echoes.getView(String).entities.length);
 		
@@ -326,7 +328,7 @@ class EdgeCaseTest extends Test {
 		entity1.add("keep");
 		entity2.add("remove");
 		MethodCounter.reset();
-		Echoes.update();
+		Echoes.activeSystems.__update__(1);
 		assertTimesCalled(3, "RemoveStringSystem.removeString");
 		Assert.equals(1, Echoes.getView(String).entities.length);
 		

--- a/test/Systems.hx
+++ b/test/Systems.hx
@@ -3,6 +3,7 @@ package;
 import Components;
 import echoes.Entity;
 import echoes.System;
+import echoes.Time;
 import haxe.extern.EitherType;
 import MethodCounter;
 
@@ -56,24 +57,24 @@ class OptionalComponentSystem extends System implements IMethodCounter {
 }
 
 class TimeCountSystem extends System implements IMethodCounter {
-	public var colorTime:Float = 0;
-	public var shapeTime:Float = 0;
-	public var colorAndShapeTime:Float = 0;
-	public var totalTime:Float = 0;
+	public var colorTime:Time = 0;
+	public var shapeTime:Time = 0;
+	public var colorAndShapeTime:Time = 0;
+	public var totalTime:Time = 0;
 	
-	@:update private function colorUpdated(color:Color, time:Float):Void {
+	@:update private function colorUpdated(color:Color, time:Time):Void {
 		colorTime += time;
 	}
 	
-	@:update private function shapeUpdated(shape:Shape, time:Float):Void {
+	@:update private function shapeUpdated(shape:Shape, time:Time):Void {
 		shapeTime += time;
 	}
 	
-	@:update private function colorAndShapeUpdated(color:Color, shape:Shape, time:Float):Void {
+	@:update private function colorAndShapeUpdated(color:Color, shape:Shape, time:Time):Void {
 		colorAndShapeTime += time;
 	}
 	
-	@:update private function update(time:Float):Void {
+	@:update private function update(time:Time):Void {
 		totalTime += time;
 	}
 }


### PR DESCRIPTION
For use cases that require integers, as in #26.

Defines a new `echoes.Time` type that is fully backwards-compatible. For anyone who doesn't need integer time, you can continue using `Float` as before, or swap over to `echoes.Time`, or a mix of both.

If you need integer time, define `echoes_millisecond_time`. Then, update your code to use `echoes.Time` instead of `Float`, and millisecond values instead of seconds.